### PR TITLE
fix: Use correct routing for oauth

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -99,10 +99,11 @@ app.get("nunjucks").addGlobal("getContext", function () {
 
 setAPIConfig({
   app,
+  sessionPath: API.PATHS.SESSION,
   baseUrl: API.BASE_URL,
 });
 
-setOAuthPaths({ app, entryPointPath: APP.PATHS.KBV });
+setOAuthPaths({ app, entryPointPath: APP.PATHS.TOY });
 
 setGTM({
   app,

--- a/src/app/toy/index.js
+++ b/src/app/toy/index.js
@@ -2,4 +2,7 @@ const express = require("express");
 
 const router = express.Router();
 
+router.get("/", (req, res, next) => {
+  return res.redirect("/oauth2/callback");
+});
 module.exports = router;

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -3,6 +3,9 @@ require("dotenv").config();
 module.exports = {
   API: {
     BASE_URL: process.env.API_BASE_URL || "http://localhost:5055",
+    PATHS: {
+      SESSION: "/session",
+    },
   },
   APP: {
     BASE_URL: process.env.EXTERNAL_WEBSITE_HOST || "http://localhost:5050",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Use correct API session path, correct web app path to `/toy` & add redirect route from `/toy`

This allows the FE to correctly route to the API with a flow of:

`/session`
`/authorization`

This should unblock hooking up a FE to test that the API is properly deployed and configured.
 
<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-1569](https://govukverify.atlassian.net/browse/OJ-1569)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-1569]: https://govukverify.atlassian.net/browse/OJ-1569?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ