### PR TITLE
Oj 1452/add intro page tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "copy-assets": "mkdir -p dist && copyfiles -u 1 src/**/*.njk dist/ src/locales/**/** dist/ && copyfiles -u 3 src/assets/javascript/*.js dist/public/scripts",
     "check-translation": "node node_modules/di-ipv-cri-common-express/scripts/checkTranslations.js",
     "test": "jest --passWithNoTests",
-    "test:browser": "cucumber-js --config test/browser/cucumber.js",
+    "test:browser": "MOCK_API=true cucumber-js --config test/browser/cucumber.js",
     "test:browser:ci": "npm-run-all -p -r start:ci test:browser"
   },
   "author": "",

--- a/src/app/toy/controllers/choose-favourite.js
+++ b/src/app/toy/controllers/choose-favourite.js
@@ -1,21 +1,21 @@
 const BaseController = require("hmpo-form-wizard").Controller;
 
+const {
+  API: {
+    PATHS: { FAVOURITE },
+  },
+} = require("../../../lib/config");
+
 class ConfirmController extends BaseController {
   async saveValues(req, res, callback) {
     super.saveValues(req, res, async () => {
-      const headers = sessionId
-        ? { "session-id": req.session.tokenId }
-        : undefined; // set the header to null should fail the req but pass the bro
+      const headers = { "session-id": req.session.tokenId };
 
       const favourite = req.sessionModel.get("favourite");
 
-      await axios.post(
-        `${POSTCODE_LOOKUP}/${postcode}`,
-        {
-          headers,
-        },
-        { toy: favourite }
-      );
+      console.log(JSON.stringify(req.sessionModel.toJSON(), null, 2));
+
+      await req.axios.post(`${FAVOURITE}`, { toy: favourite }, { headers });
     });
   }
 }

--- a/src/views/toy/choose-favourite.njk
+++ b/src/views/toy/choose-favourite.njk
@@ -1,3 +1,7 @@
 {% extends "base-form.njk" %}
 
 {% set gtmJourney = "toy - middle" %}
+
+{% block submitButton %}
+  {{ hmpoSubmit(ctx, {id: "continue", text: translate("buttons.next")}) }}
+{% endblock %}

--- a/src/views/toy/intro.njk
+++ b/src/views/toy/intro.njk
@@ -3,3 +3,7 @@
 {% set hmpoPageKey = "intro" %}
 {% set hmpoPageContent = "intro" %}
 {% set gtmJourney = "toy - start" %}
+
+{% block submitButton %}
+  {{ hmpoSubmit(ctx, {id: "continue", text: translate("buttons.next")}) }}
+{% endblock %}

--- a/test/browser/cucumber.js
+++ b/test/browser/cucumber.js
@@ -5,6 +5,7 @@ module.exports = {
     require: [
       "./test/browser/support/**/*.js",
       "./test/browser/step_definitions/**/*.js",
+      "./test/browser/pages/*.js",
     ],
   },
 };

--- a/test/browser/features/error-session.feature
+++ b/test/browser/features/error-session.feature
@@ -2,6 +2,7 @@ Feature: Error handling
 
   API Errors at the start of the journey
 
+  @mock-api:test-session-500
   Scenario: Session error
     Given Error Eric is using the system
     And they have started the toy journey

--- a/test/browser/features/happy.feature
+++ b/test/browser/features/happy.feature
@@ -1,0 +1,11 @@
+Feature: Happy path
+
+  Successful journey through the system and back to the RP
+
+  @mock-api:toy-success @wip
+  Scenario: Toy Happy Path
+    Given Happy Harriet is using the system
+    When they have started the toy journey
+    Then they should see the intro page
+    And they continue to choose favourite
+#    Then they should see the choose favourite page

--- a/test/browser/features/happy.feature
+++ b/test/browser/features/happy.feature
@@ -8,4 +8,4 @@ Feature: Happy path
     When they have started the toy journey
     Then they should see the intro page
     And they continue to choose favourite
-#    Then they should see the choose favourite page
+    Then they should see the choose favourite page

--- a/test/browser/pages/choose-favourite.js
+++ b/test/browser/pages/choose-favourite.js
@@ -1,0 +1,19 @@
+module.exports = class PlaywrightDevPage {
+  /**
+   * @param {import('@playwright/test').Page} page
+   */
+  constructor(page) {
+    this.page = page;
+    this.path = "/toy/choose-favourite";
+  }
+
+  async continue() {
+    await this.page.click("#continue");
+  }
+
+  isCurrentPage() {
+    const { pathname } = new URL(this.page.url());
+
+    return pathname == this.path;
+  }
+};

--- a/test/browser/pages/index.js
+++ b/test/browser/pages/index.js
@@ -1,4 +1,5 @@
 module.exports = {
+  IntroPage: require("./intro.js"),
   ErrorPage: require("./error.js"),
   RelyingPartyPage: require("./relying-party.js"),
 };

--- a/test/browser/pages/index.js
+++ b/test/browser/pages/index.js
@@ -1,4 +1,5 @@
 module.exports = {
+  ChooseFavouritePage: require("./choose-favourite.js"),
   IntroPage: require("./intro.js"),
   ErrorPage: require("./error.js"),
   RelyingPartyPage: require("./relying-party.js"),

--- a/test/browser/pages/intro.js
+++ b/test/browser/pages/intro.js
@@ -1,0 +1,19 @@
+module.exports = class PlaywrightDevPage {
+  /**
+   * @param {import('@playwright/test').Page} page
+   */
+  constructor(page) {
+    this.page = page;
+    this.path = "/toy/intro";
+  }
+
+  async continue() {
+    await this.page.click("#continue");
+  }
+
+  isCurrentPage() {
+    const { pathname } = new URL(this.page.url());
+
+    return pathname == this.path;
+  }
+};

--- a/test/browser/step_definitions/choose-favourite.js
+++ b/test/browser/step_definitions/choose-favourite.js
@@ -1,0 +1,19 @@
+const { Given, Then, When } = require("@cucumber/cucumber");
+const { ChooseFavouritePage } = require("../pages");
+const { expect } = require("chai");
+
+Given(
+  /^they (?:have )?start(?:ed)? the address journey$/,
+  async function () {}
+);
+
+Then(/they should see the choose favourite page$/, async function () {
+  const chooseFavouritePage = new ChooseFavouritePage(this.page);
+
+  expect(chooseFavouritePage.isCurrentPage()).to.be.true;
+});
+
+Then("they continue to ??", async function () {
+  const chooseFavouritePage = new ChooseFavouritePage(this.page);
+  await chooseFavouritePage.continue();
+});

--- a/test/browser/step_definitions/intro.js
+++ b/test/browser/step_definitions/intro.js
@@ -1,0 +1,14 @@
+const { Given, Then, When } = require("@cucumber/cucumber");
+const { IntroPage } = require("../pages");
+const { expect } = require("chai");
+
+Then(/they should see the intro page$/, async function () {
+  const introPage = new IntroPage(this.page);
+
+  expect(introPage.isCurrentPage()).to.be.true;
+});
+
+Then("they continue to choose favourite", async function () {
+  const introPage = new IntroPage(this.page);
+  await introPage.continue();
+});

--- a/test/browser/support/setup.js
+++ b/test/browser/support/setup.js
@@ -42,29 +42,12 @@ Before(async function ({ pickle } = {}) {
 
   const header = tag?.name.substring(10);
 
-  this.SCENARIO_ID_HEADER = header;
-
-  try {
-    await axios.get(`${process.env.API_BASE_URL}/__reset/${header}`);
-  } catch (e) {
-    /* eslint-disable no-console */
-    console.log("Error resetting mock");
-    console.log(`${process.env.API_BASE_URL}/__reset/${header}`);
-    console.log(e.message);
-    /* eslint-enable no-console */
-    throw e;
-  }
+  this.TESTING_CLIENT_ID = header;
 });
 
 // Create a new test context and page per scenario
 Before(async function () {
   this.context = await global.browser.newContext({});
-
-  if (this.SCENARIO_ID_HEADER) {
-    await this.context.setExtraHTTPHeaders({
-      "x-scenario-id": this.SCENARIO_ID_HEADER,
-    });
-  }
 
   this.page = await this.context.newPage();
 });


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- Add functionality to use `client_id` to manipulate the data returned from the Imposter stub
- Add test for seeing the intro page and the choose favourite page

This was tested locally by runnning `imposter up --port 8050` and `npm run start:ci` and `npm run test:browser`

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-1452](https://govukverify.atlassian.net/browse/OJ-1452)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-1452]: https://govukverify.atlassian.net/browse/OJ-1452?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ