### PR TITLE
fix: Use /toy route for toy pages

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -114,6 +114,6 @@ router.use(setAxiosDefaults);
 
 router.use("/oauth2", commonExpress.routes.oauth2);
 
-router.use("/", require("./app/toy"));
+router.use("/toy", require("./app/toy"));
 
 router.use(commonExpress.lib.errorHandling.redirectAsErrorToCallback);

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -12,7 +12,7 @@ module.exports = {
   APP: {
     BASE_URL: process.env.EXTERNAL_WEBSITE_HOST || "http://localhost:5050",
     PATHS: {
-      TOY: "/",
+      TOY: "/toy/",
     },
     ANALYTICS: {
       ID: process.env.GTM_ID,

--- a/test/browser/pages/choose-favourite.js
+++ b/test/browser/pages/choose-favourite.js
@@ -4,7 +4,7 @@ module.exports = class PlaywrightDevPage {
    */
   constructor(page) {
     this.page = page;
-    this.path = "/choose-favourite";
+    this.path = "/toy/choose-favourite";
   }
 
   async continue() {

--- a/test/browser/pages/intro.js
+++ b/test/browser/pages/intro.js
@@ -4,7 +4,7 @@ module.exports = class PlaywrightDevPage {
    */
   constructor(page) {
     this.page = page;
-    this.path = "/intro";
+    this.path = "/toy/intro";
   }
 
   async continue() {


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- All journeys need to start via the /oauth route
- This journey is then redirected to the start of the toy router
- Allowing the default / route makes the entry point for tests more confusing, and has lead to bugs in the past
- 404ing on the default / route and using /toy instead removes the opportunity for these buggy tests

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-XXXX](https://govukverify.atlassian.net/browse/OJ-XXXX)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
