### PR TITLE
remove -v1 from api import stack name

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -273,7 +273,7 @@ Resources:
               Value: !Sub
                 - "https://${APIGatewayId}.execute-api.eu-west-2.amazonaws.com/${Environment}"
                 - APIGatewayId:
-                    Fn::ImportValue: toy-cri-api-v1-PrivateToyApiGatewayId
+                    Fn::ImportValue: toy-cri-api-PrivateToyApiGatewayId
                   Environment: !Ref Environment
             - Name: EXTERNAL_WEBSITE_HOST
               Value: !GetAtt ApiGwHttpEndpoint.ApiEndpoint


### PR DESCRIPTION
## Proposed changes

### What changed

The API import name has been updated to reflect the api pipeline name change (removal of v1)

### Why did it change

This enables the toy front deployment

### Issue tracking

- [OJ-1905](https://govukverify.atlassian.net/browse/OJ-1905)

## Checklists

### Environment variables or secrets

- [X] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-1905]: https://govukverify.atlassian.net/browse/OJ-1905?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ